### PR TITLE
use NODE_ENV to auto switch localhost or prod

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -1,1 +1,2 @@
-export const NEXT_PUBLIC_URL = 'https://zizzamia.xyz';
+// use NODE_ENV to not have to change config based on where it's deployed
+export const NEXT_PUBLIC_URL = process.env.NODE_ENV == "development" ? 'http://localhost:3000' : 'https://zizzamia.xyz';


### PR DESCRIPTION
simple change to `config.ts` that stores the public URL.

When currently deploying one needs to always change config.ts in the template or switch the template to environment variables.

This simple check if NODE_ENV is development makes that step just a change of the prod domain once.